### PR TITLE
Allow to install test dependencies

### DIFF
--- a/.github/workflows/ansible-integration-workflow.yaml
+++ b/.github/workflows/ansible-integration-workflow.yaml
@@ -76,6 +76,11 @@ jobs:
           # Writing molecule config for docker
           echo "${{ inputs.molecule-config}}" > molecule/github/molecule.yml
 
+          # Copy test dependencies if they exist
+          if test -f "molecule/default/requirements.yml"; then
+            cp molecule/default/requirements.yml molecule/github/requirements.yml
+          fi
+
           # Add prepare playbook if exists
           if test -f "molecule/default/prepare.yml"; then
             yq e --inplace '.provisioner.playbooks += {"prepare":"../default/prepare.yml"}' molecule/github/molecule.yml

--- a/.github/workflows/ansible-integration-workflow.yaml
+++ b/.github/workflows/ansible-integration-workflow.yaml
@@ -53,15 +53,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Install test dependencies
-        run: |
-          # Copy test dependencies if they exist
-          if test -f "molecule/default/requirements.yml"; then
-            ansible-galaxy install -r molecule/default/requirements.yml
-          fi
+      - name: Install ansible-lint
+        run: pip install ansible-lint
 
       - name: Ansible Lint
-        uses: ansible-community/ansible-lint-action@v6
+        run: ansible-lint .
 
   test:
     name: Molecule
@@ -104,8 +100,10 @@ jobs:
         run: pip3 install -r molecule/requirements.txt
 
       - name: Install Ansible Role Requirements
-        run: ansible-galaxy install -r requirements.yml
-        continue-on-error: true
+        run: |
+          if test -f "requirements.yml"; then
+            ansible-galaxy install -r requirements.yml
+          fi
 
       - name: Disable AppArmor (MySQL)
         run: |

--- a/.github/workflows/ansible-integration-workflow.yaml
+++ b/.github/workflows/ansible-integration-workflow.yaml
@@ -56,6 +56,12 @@ jobs:
       - name: Install ansible-lint
         run: pip install ansible-lint
 
+      - name: Install Ansible Role Requirements
+        run: |
+          if test -f "requirements.yml"; then
+            ansible-galaxy install -r requirements.yml
+          fi
+
       - name: Ansible Lint
         run: ansible-lint .
 

--- a/.github/workflows/ansible-integration-workflow.yaml
+++ b/.github/workflows/ansible-integration-workflow.yaml
@@ -53,6 +53,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Install test dependencies
+        run: |
+          # Copy test dependencies if they exist
+          if test -f "molecule/default/requirements.yml"; then
+            ansible-galaxy install -r molecule/default/requirements.yml
+          fi
+
       - name: Ansible Lint
         uses: ansible-community/ansible-lint-action@v6
 


### PR DESCRIPTION
- Install ansible-lint directly. Otherwise it didn't pickup the build dependencies.
- Install role dependencies so we can lint their usage as well

Used in https://github.com/systemli/ansible-role-userli/pull/47