### PR TITLE
Run Github workflows against `debian12` and `debian11`

### DIFF
--- a/.github/workflows/ansible-integration-workflow.yaml
+++ b/.github/workflows/ansible-integration-workflow.yaml
@@ -8,7 +8,7 @@ on:
         required: false
         description: "List of distributions to test against the Role"
         type: string
-        default: '[ "debian11", "debian10" ]'
+        default: '[ "debian12", "debian11" ]'
       python-dependencies:
         required: false
         description: "Default pip dependencies for molecule"


### PR DESCRIPTION
Forgot this in PR #28.